### PR TITLE
Semigroups, Monoids, Zips, and `AsRecord`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for prairie
 
+## 0.0.4.0
+
+- [#13](https://github.com/parsonsmatt/prairie/pull/13)
+    - Introduce `Prairie.Semigroup`, allowing you to combine two records by semigroup-appending their fields together.
+    - Introduce `Prairie.Zip`, allowing you to combine two records by specifying how to combine their fields. This fuels `Prairie.Semigroup`.
+    - Introduce `Prairie.Monoid`, allowing you to make an `emptyRecord` with `mempty` at each field.
+    - Introduce `Prairie.AsRecord`, allowing you to derive instances for records based on their `Record` and `FieldDict` instances.
+
 ## 0.0.3.0
 
 - [#8](https://github.com/parsonsmatt/prairie/pull/8)

--- a/prairie.cabal
+++ b/prairie.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           prairie
-version:        0.0.3.0
+version:        0.0.4.0
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/prairie#readme>
 homepage:       https://github.com/parsonsmatt/prairie#readme
 bug-reports:    https://github.com/parsonsmatt/prairie/issues

--- a/prairie.cabal
+++ b/prairie.cabal
@@ -24,6 +24,7 @@ source-repository head
 library
   exposed-modules:
       Prairie
+      Prairie.AsRecord
       Prairie.Class
       Prairie.Update
       Prairie.Diff

--- a/prairie.cabal
+++ b/prairie.cabal
@@ -28,8 +28,11 @@ library
       Prairie.Update
       Prairie.Diff
       Prairie.Fold
+      Prairie.Zip
       Prairie.Traverse
       Prairie.TH
+      Prairie.Semigroup
+      Prairie.Monoid
 
   build-depends:
       base              >= 4.13 && < 5

--- a/src/Prairie.hs
+++ b/src/Prairie.hs
@@ -7,7 +7,10 @@ module Prairie
     , module Prairie.Diff
     , module Prairie.Fold
     , module Prairie.Traverse
+    , module Prairie.Zip
     , module Prairie.TH
+    , module Prairie.Semigroup
+    , module Prairie.Monoid
     ) where
 
 import Prairie.Class
@@ -16,3 +19,6 @@ import Prairie.Fold
 import Prairie.TH
 import Prairie.Traverse
 import Prairie.Update
+import Prairie.Zip
+import Prairie.Semigroup
+import Prairie.Monoid

--- a/src/Prairie/AsRecord.hs
+++ b/src/Prairie/AsRecord.hs
@@ -4,9 +4,40 @@
 module Prairie.AsRecord where
 
 import Prairie.Class
+import Prairie.Semigroup
+import Prairie.Monoid
 
+-- | This @newtype@ is intended for use with @DerivingVia@.
+--
+-- For an example use, let's consider this @User@ datatype:
+--
+-- > data Foo = Foo
+-- >     { ints :: [Int]
+-- >     , char :: First Char
+-- >     }
+-- >
+-- > mkRecord ''Foo
+--
+-- Let's say we want to define an instance of 'Semigroup' for this type, so
+-- that we can combine two of them. Ordinarily, we'd need to write
+-- a boilerplate-y instance:
+--
+-- > instance Semigroup Foo where
+-- >     f0 <> f1 = Foo
+-- >         { ints = f0.ints <> f1.ints
+-- >         , char = f0.char <> f1.char
+-- >         }
+--
+-- With @DerivingVia@, we can use 'AsRecord' to provide it easily:
+--
+-- @
+-- deriving via AsRecord Foo instance Semigroup Foo
+-- @
 newtype AsRecord rec = AsRecord { unAsRecord :: rec }
 
 instance (Record rec, FieldDict Semigroup rec) => Semigroup (AsRecord rec) where
     AsRecord r0 <> AsRecord r1 =
-        fold
+        AsRecord (appendRecord r0 r1)
+
+instance (Record rec, FieldDict Semigroup rec, FieldDict Monoid rec) => Monoid (AsRecord rec) where
+    mempty = AsRecord emptyRecord

--- a/src/Prairie/AsRecord.hs
+++ b/src/Prairie/AsRecord.hs
@@ -1,0 +1,12 @@
+-- | This module contains a newtype 'AsRecord' which is used to provide
+-- a variety of default instances for types based on their 'Record'
+-- instance.
+module Prairie.AsRecord where
+
+import Prairie.Class
+
+newtype AsRecord rec = AsRecord { unAsRecord :: rec }
+
+instance (Record rec, FieldDict Semigroup rec) => Semigroup (AsRecord rec) where
+    AsRecord r0 <> AsRecord r1 =
+        fold

--- a/src/Prairie/AsRecord.hs
+++ b/src/Prairie/AsRecord.hs
@@ -4,8 +4,8 @@
 module Prairie.AsRecord where
 
 import Prairie.Class
-import Prairie.Semigroup
 import Prairie.Monoid
+import Prairie.Semigroup
 
 -- | This @newtype@ is intended for use with @DerivingVia@.
 --
@@ -33,11 +33,19 @@ import Prairie.Monoid
 -- @
 -- deriving via AsRecord Foo instance Semigroup Foo
 -- @
+--
+-- @since 0.0.4.0
 newtype AsRecord rec = AsRecord { unAsRecord :: rec }
 
+-- |
+--
+-- @since 0.0.4.0
 instance (Record rec, FieldDict Semigroup rec) => Semigroup (AsRecord rec) where
     AsRecord r0 <> AsRecord r1 =
         AsRecord (appendRecord r0 r1)
 
+-- |
+--
+-- @since 0.0.4.0
 instance (Record rec, FieldDict Semigroup rec, FieldDict Monoid rec) => Monoid (AsRecord rec) where
     mempty = AsRecord emptyRecord

--- a/src/Prairie/Monoid.hs
+++ b/src/Prairie/Monoid.hs
@@ -1,0 +1,8 @@
+module Prairie.Monoid where
+
+import Prairie.Class
+
+-- | Create a 'mempty' 'Record' assuming that all of the fields of the
+-- record have a 'Monoid' instance.
+emptyRecord :: (Record rec, FieldDict Monoid rec) => rec
+emptyRecord = tabulateRecord (\field -> withFieldDict @Monoid field mempty)

--- a/src/Prairie/Monoid.hs
+++ b/src/Prairie/Monoid.hs
@@ -4,5 +4,7 @@ import Prairie.Class
 
 -- | Create a 'mempty' 'Record' assuming that all of the fields of the
 -- record have a 'Monoid' instance.
+--
+-- @since 0.0.4.0
 emptyRecord :: (Record rec, FieldDict Monoid rec) => rec
 emptyRecord = tabulateRecord (\field -> withFieldDict @Monoid field mempty)

--- a/src/Prairie/Semigroup.hs
+++ b/src/Prairie/Semigroup.hs
@@ -1,0 +1,15 @@
+-- | This module provides the ability to append two records using '(<>)',
+-- provided that all of their fields have an instance of 'Semigroup'.
+module Prairie.Semigroup where
+
+import Prairie.Zip
+import Prairie.Class
+
+-- | Zip two records together using a 'Semigroup' append.
+appendRecord
+    :: forall rec. (Record rec, FieldDict Semigroup rec)
+    => rec
+    -> rec
+    -> rec
+appendRecord =
+    zipWithRecord (\a b field -> withFieldDict @Semigroup field (a <> b))

--- a/src/Prairie/Semigroup.hs
+++ b/src/Prairie/Semigroup.hs
@@ -2,10 +2,12 @@
 -- provided that all of their fields have an instance of 'Semigroup'.
 module Prairie.Semigroup where
 
-import Prairie.Zip
 import Prairie.Class
+import Prairie.Zip
 
 -- | Zip two records together using a 'Semigroup' append.
+--
+-- @since 0.0.4.0
 appendRecord
     :: forall rec. (Record rec, FieldDict Semigroup rec)
     => rec

--- a/src/Prairie/Zip.hs
+++ b/src/Prairie/Zip.hs
@@ -17,6 +17,8 @@ import Prairie.Fold
 --                 a + b
 --     )
 -- @
+--
+-- @since 0.0.4.0
 zipWithRecord
     :: forall rec. (Record rec)
     => (forall ty. ty -> ty -> Field rec ty -> ty)

--- a/src/Prairie/Zip.hs
+++ b/src/Prairie/Zip.hs
@@ -1,0 +1,32 @@
+module Prairie.Zip where
+
+import Prairie.Class
+import Prairie.Fold
+
+-- | Take two records and zip them together with the provided function.
+--
+-- The field is given for the final parameter in the function, allowing you to use @LambdaCase@.
+--
+-- @
+-- zipWithRecord
+--     (\a b ->
+--         \case
+--             UserName ->
+--                 a <> b
+--             UserAge ->
+--                 a + b
+--     )
+-- @
+zipWithRecord
+    :: forall rec. (Record rec)
+    => (forall ty. ty -> ty -> Field rec ty -> ty)
+    -> rec
+    -> rec
+    -> rec
+zipWithRecord k r0 r1 =
+    foldRecord f r0 r0
+  where
+      f :: ty -> rec -> Field rec ty -> rec
+      f v0 rec field =
+          let v1 = getRecordField field r1
+           in setRecordField field (k v0 v1 field) rec

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,18 +1,19 @@
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE FlexibleContexts, ConstraintKinds #-}
-{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE BlockArguments #-}
+{-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeApplications #-}
@@ -25,14 +26,14 @@ module Main where
 
 import Prairie
 
-import GHC.Records
 import Control.Lens
 import Control.Monad
 import Data.Aeson
 import Data.Kind (Type)
 import Data.Monoid
-import Test.Hspec
+import GHC.Records
 import Prairie.AsRecord
+import Test.Hspec
 
 data User = User { name :: String, age :: Int }
   deriving (Show, Eq)

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,9 @@
-{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE FlexibleContexts, ConstraintKinds #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE BlockArguments #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
@@ -19,6 +24,7 @@ module Main where
 
 import Prairie
 
+import GHC.Records
 import Control.Lens
 import Control.Monad
 import Data.Aeson

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,7 +9,6 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE RankNTypes #-}

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE OverloadedRecordDot #-}
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE FlexibleContexts, ConstraintKinds #-}
@@ -31,6 +32,7 @@ import Data.Aeson
 import Data.Kind (Type)
 import Data.Monoid
 import Test.Hspec
+import Prairie.AsRecord
 
 data User = User { name :: String, age :: Int }
   deriving (Show, Eq)
@@ -41,6 +43,15 @@ deriving instance Eq (Field User a)
 deriving instance Show (Field User a)
 
 exampleUser = User "Alice" 30
+
+data Foo = Foo
+    { ints :: [Int]
+    , char :: First Char
+    }
+
+mkRecord ''Foo
+
+deriving via AsRecord Foo instance Semigroup Foo
 
 data T a = T { x :: a, y :: Int }
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -48,10 +48,12 @@ data Foo = Foo
     { ints :: [Int]
     , char :: First Char
     }
+    deriving (Show, Eq)
 
 mkRecord ''Foo
 
 deriving via AsRecord Foo instance Semigroup Foo
+deriving via AsRecord Foo instance Monoid Foo
 
 data T a = T { x :: a, y :: Int }
 
@@ -214,3 +216,31 @@ main = hspec $ do
                     User { name = "", age = 30 }
                     `shouldBe`
                         Nothing
+
+        describe "Semigroup" do
+            it "can combine two records" do
+                let f0 = Foo [1] (First Nothing)
+                    f1 = Foo [2,3] (First (Just 'a'))
+                f0 <> f1
+                    `shouldBe`
+                        Foo [1,2,3] (First (Just 'a'))
+
+        describe "Monoid" do
+            it "can produce an empty record" do
+                let obvious =
+                        Foo mempty mempty
+                mempty `shouldBe` obvious
+
+        describe "Zip" do
+            it "can combine two records" do
+                let u0 = User "Matt" 35
+                    u1 = User "ttaM" 53
+                zipWithRecord (\a b -> \case
+                    UserName ->
+                        a <> b
+                    UserAge ->
+                        a + b
+                    ) u0 u1
+                    `shouldBe`
+                        User "MattttaM" (35 + 53)
+


### PR DESCRIPTION
This PR introduces `Prairie.Semigroup`, allowing you to `appendRecord :: (Record rec, FieldDict Semigroup rec) => rec -> rec -> rec`. We also get `Prairie.Monoid`, giving you `emptyRecord :: (Record rec, FieldDict Monoid rec) => rec`. These are pretty self-explanatory.

`appendRecord` is implemented with `zipWithRecord :: (Record rec) => (forall ty. ty -> ty -> Field rec ty -> ty) -> rec -> rec -> rec`, also introduced here. This allows you to combine two records with a function specifying how to combine the values.

Finally, we provide `AsRecord`, a newtype for `DerivingVia` which lets you derive `Monoid` and `Semigroup` instances using the behavior of `appendRecord` and `emptyRecord`.

Before submitting your PR, check that you've:

- [x] Bumped the version number.
- [x] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [x] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [x] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [x] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
