### PR TITLE
Drop `lens` dependency

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for prairie
 
+## 0.0.4.1
+
+- [#18](https://github.com/parsonsmatt/prairie/pull/18)
+    - Drop `lens` dependency
+
 ## 0.0.4.0
 
 - [#13](https://github.com/parsonsmatt/prairie/pull/13)
@@ -25,7 +30,7 @@
 - [#2](https://github.com/parsonsmatt/prairie/pull/2)
     - Add `tabulateRecordA` to `Record` class. `tabulate` and `allFields` are now normal functions.
     - Provide a default implementation of `recordFieldLabel` for `Show`able fields.
-    
+
 ## 0.0.1.1
 
 * [#4](https://github.com/parsonsmatt/prairie/pull/4)

--- a/prairie.cabal
+++ b/prairie.cabal
@@ -37,15 +37,16 @@ library
 
   build-depends:
       base              >= 4.13 && < 5
-    , aeson             
+    , aeson
     , constraints
     , containers
-    , lens
+    , mtl
     , template-haskell  >= 2.15 && < 2.22
     , text
 
   other-modules:
       Paths_prairie
+      Prairie.Internal
   hs-source-dirs:
       src
   default-language: Haskell2010

--- a/prairie.cabal
+++ b/prairie.cabal
@@ -1,7 +1,7 @@
 cabal-version: 1.12
 
 name:           prairie
-version:        0.0.4.0
+version:        0.0.4.1
 description:    Please see the README on GitHub at <https://github.com/parsonsmatt/prairie#readme>
 homepage:       https://github.com/parsonsmatt/prairie#readme
 bug-reports:    https://github.com/parsonsmatt/prairie/issues

--- a/src/Prairie/Class.hs
+++ b/src/Prairie/Class.hs
@@ -16,9 +16,10 @@
 -- @since 0.0.1.0
 module Prairie.Class where
 
-import Control.Lens (Lens', set, view, Identity(..), Const(..))
 import Data.Aeson (ToJSON(..), FromJSON(..), withText)
 import Data.Constraint (Dict(..))
+import Data.Functor.Const (Const(..))
+import Data.Functor.Identity (Identity(..))
 import Data.Kind (Constraint, Type)
 import Data.Map (Map)
 import qualified Data.Map as Map
@@ -27,6 +28,8 @@ import qualified Data.Text as Text
 import Data.Typeable ((:~:)(..), Typeable, eqT)
 import GHC.OverloadedLabels (IsLabel(..))
 import GHC.TypeLits (Symbol)
+
+import Prairie.Internal (Lens', set, view)
 
 -- | Instances of this class have a datatype 'Field' which allow you to
 -- represent fields as a concrete datatype. This allows you to have

--- a/src/Prairie/Internal.hs
+++ b/src/Prairie/Internal.hs
@@ -1,0 +1,25 @@
+module Prairie.Internal where
+
+import Data.Functor.Const (Const(..))
+import Data.Functor.Identity (Identity(..))
+import Control.Monad.Reader (MonadReader(..), asks)
+
+type Getting r s a = (a -> Const r a) -> s -> Const r s
+
+type ASetter s t a b = (a -> Identity b) -> s -> Identity t
+
+type Lens s t a b = forall f. Functor f => (a -> f b) -> s -> f t
+
+type Lens' s a = Lens s s a a
+
+set :: ASetter s t a b -> b -> s -> t
+set l b = runIdentity . l (\_ -> Identity b)
+{-# INLINE set #-}
+
+lens :: (s -> a) -> (s -> b -> t) -> Lens s t a b
+lens sa sbt afb s = sbt s <$> afb (sa s)
+{-# INLINE lens #-}
+
+view :: MonadReader s m => Getting a s a -> m a
+view l = asks (getConst . l Const)
+{-# INLINE view #-}

--- a/src/Prairie/TH.hs
+++ b/src/Prairie/TH.hs
@@ -7,13 +7,13 @@ module Prairie.TH where
 
 import Data.Constraint (Dict(..))
 import Language.Haskell.TH
-import Control.Lens (lens)
 import qualified Data.List as List
 import Data.Traversable (for)
 import Data.Char (toUpper, toLower)
 import qualified Data.Text as Text
 
 import Prairie.Class
+import Prairie.Internal (lens)
 
 -- | Create an instance of the 'Record' type class.
 --

--- a/src/Prairie/Update.hs
+++ b/src/Prairie/Update.hs
@@ -4,10 +4,10 @@
 module Prairie.Update where
 
 import Data.Aeson (ToJSON(..), FromJSON(..), object, withObject, (.:), (.=))
-import Control.Lens (set)
 import Data.Typeable (Typeable, (:~:)(..), eqT)
 
 import Prairie.Class
+import Prairie.Internal (set)
 
 -- | An operation representing an update against the 'rec' in question.
 --


### PR DESCRIPTION
Getters, setters, and lenses can be defined without depending on the `lens` library.

Removes these from `prairie`'s dependency footprint:

```
adjunctions
call-stack
free
invariant
kan-extensions
lens
parallel
profunctors
reflection
semigroups
transformers-base
void
```

It's not as much as I was hoping, since `prairie` depends on `aeson` which has a big dependency footprint, but I figured I'd push it anyways in case you're interested 🤷 

---

Before submitting your PR, check that you've:

- [ ] Bumped the version number.
- [ ] Documented new APIs with [Haddock markup](https://www.haskell.org/haddock/doc/html/index.html).
- [ ] Added [`@since` declarations](http://haskell-haddock.readthedocs.io/en/latest/markup.html#since) to the Haddock.
- [ ] Ran `stylish-haskell` and otherwise adhered to the [style guide](https://github.com/bitemyapp/esqueleto/blob/master/style-guide.yaml).

After submitting your PR:

- [ ] Update the Changelog.md file with a link to your PR.
- [ ] Check that CI passes (or if it fails, for reasons unrelated to your change, like CI timeouts).

<!---Thanks so much for contributing! :)

_If these checkboxes don't apply to your PR, you can delete them_

If you're unsure on what the new version number should be, feel free to ask.

-->
