### PR TITLE
Support type families in mkRecord (opt-in)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,9 @@
 
 - [#26](https://github.com/parsonsmatt/prairie/pull/26)
     - `mkRecord` now supports record types with type variables (e.g. `data Box a = Box { contents :: a }`).
+- [#27](https://github.com/parsonsmatt/prairie/pull/27)
+    - Added `mkRecordWith`, the abstract `PrairieOptions` type, and `defaultPrairieOptions`. `mkRecord` is now `mkRecordWith defaultPrairieOptions` and its generated code is unchanged. The `PrairieOptions` constructor is intentionally not exported, so adding options later is not a breaking change.
+    - `mkRecordWith defaultPrairieOptions { useTypeEquality = True }` generates the `SymbolToField` instances with a `~` equality constraint binding the field type, instead of placing it directly in the instance head. This admits field types that an instance head rejects — most notably type-family applications (e.g. `data Test m = Test { field :: Family m Int }`). It is opt-in because the `~` constraint requires the `TypeOperators` extension at the use site; default `mkRecord` behaviour is unaffected. Using a type-family field without enabling `useTypeEquality` now produces a descriptive error.
 
 ## 0.1.1.0
 

--- a/prairie.cabal
+++ b/prairie.cabal
@@ -92,6 +92,7 @@ test-suite prairie-test
       Prairie.DuplicateFieldSpec
       Prairie.NoFieldSelectorSpec
       Prairie.TypeVariablesSpec
+      Prairie.TypeFamilySpec
   hs-source-dirs:
       test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N

--- a/src/Prairie/TH.hs
+++ b/src/Prairie/TH.hs
@@ -3,7 +3,17 @@
 -- | Helpers for generating instances of the 'Record' type class.
 --
 -- @since 0.0.1.0
-module Prairie.TH where
+module Prairie.TH
+    ( -- * Generating @Record@ instances
+      mkRecord
+    , mkRecordWith
+
+      -- * Configuration
+      -- $options
+    , PrairieOptions
+    , defaultPrairieOptions
+    , useTypeEquality
+    ) where
 
 import Data.Char (toLower, toUpper)
 import Data.Constraint (Dict (..))
@@ -75,7 +85,74 @@ import Prairie.Internal (lens)
 --
 -- @since 0.0.1.0
 mkRecord :: Name -> DecsQ
-mkRecord u = do
+mkRecord = mkRecordWith defaultPrairieOptions
+
+-- $options
+--
+-- 'PrairieOptions' is an opaque type. Configure it by record-updating
+-- 'defaultPrairieOptions' using the exported field accessors, e.g.
+--
+-- @
+-- 'defaultPrairieOptions' { 'useTypeEquality' = True }
+-- @
+--
+-- The constructor is intentionally not exported so that future options can
+-- be added without it being a breaking change.
+
+-- | Options controlling how 'mkRecordWith' generates instances.
+--
+-- This type is abstract; see 'defaultPrairieOptions' and the individual field
+-- accessors ('useTypeEquality').
+--
+-- @since 0.1.2.0
+data PrairieOptions = PrairieOptions
+    { useTypeEquality :: Bool
+    -- ^ Generate the 'SymbolToField' instances using a @~@ equality
+    -- constraint to bind the field type, rather than placing the field type
+    -- directly in the instance head:
+    --
+    -- @
+    -- -- with useTypeEquality = False (default):
+    -- instance SymbolToField \"foo\" Rec Ty where ...
+    --
+    -- -- with useTypeEquality = True:
+    -- instance (field ~ Ty) => SymbolToField \"foo\" Rec field where ...
+    -- @
+    --
+    -- This admits field types that are not permitted directly in an instance
+    -- head — most notably type-family applications (e.g. @field :: Family m
+    -- Int@), but anything else that an instance head rejects too. The cost is
+    -- that the calling module must enable the @TypeOperators@ extension, so it
+    -- is off by default: the generated code is then identical to previous
+    -- versions of @prairie@. When it is off and a field is found to use a type
+    -- family, 'mkRecordWith' fails with a descriptive error pointing here.
+    --
+    -- @since 0.1.2.0
+    }
+
+-- | The default 'PrairieOptions'. 'mkRecord' is @'mkRecordWith' 'defaultPrairieOptions'@,
+-- and the generated code is identical to previous versions of @prairie@.
+--
+-- @since 0.1.2.0
+defaultPrairieOptions :: PrairieOptions
+defaultPrairieOptions =
+    PrairieOptions
+        { useTypeEquality = False
+        }
+
+-- | Like 'mkRecord', but with control over code generation via 'PrairieOptions'.
+--
+-- For example, to allow fields whose type is a type-family application:
+--
+-- @
+-- {-\# LANGUAGE TypeOperators \#-}
+--
+-- mkRecordWith defaultPrairieOptions { useTypeEquality = True } ''MyRecord
+-- @
+--
+-- @since 0.1.2.0
+mkRecordWith :: PrairieOptions -> Name -> DecsQ
+mkRecordWith opts u = do
     ty <- reify u
     (typeName, con, tyvars) <-
         case ty of
@@ -300,8 +377,25 @@ mkRecord u = do
                 (ConT ''FieldDict `AppT` VarT constraintVar `AppT` instanceHead)
                 fieldDictDecl
 
-    symbolToFieldInstances <-
-        fmap concat $ for names'types $ \(fieldName, typ) -> do
+    let
+        -- Bind the field type through a @~@ equality constraint. Needed for
+        -- field types that cannot appear directly in an instance head (e.g.
+        -- type-family applications); requires @TypeOperators@ at the use site.
+        equalitySymbolToField fieldName typ = do
+            retType <- newName "field"
+            [d|
+                instance
+                    ($(varT retType) ~ $(pure typ))
+                    => SymbolToField
+                        $(litT (strTyLit (nameBase fieldName)))
+                        $(pure instanceHead)
+                        $(varT retType)
+                    where
+                    symbolToField = $(conE (mkConstrFieldName fieldName))
+                |]
+        -- Place the field type directly in the instance head, exactly as
+        -- @prairie@ always has (no @TypeOperators@ required).
+        directSymbolToField fieldName typ =
             [d|
                 instance
                     SymbolToField
@@ -312,11 +406,81 @@ mkRecord u = do
                     symbolToField = $(conE (mkConstrFieldName fieldName))
                 |]
 
+    symbolToFieldInstances <-
+        fmap concat $ for names'types $ \(fieldName, typ) ->
+            if useTypeEquality opts
+                then equalitySymbolToField fieldName typ
+                else do
+                    -- The direct form can't express a type-family field. Detect
+                    -- that and fail with guidance rather than letting GHC emit a
+                    -- confusing instance-head error.
+                    mentionsFamily <- typeMentionsFamily typ
+                    if mentionsFamily
+                        then fail (typeFamilyFieldError typeName fieldName typ)
+                        else directSymbolToField fieldName typ
+
     pure $
         [ recordInstance
         , fieldDictInstance
         ]
             ++ symbolToFieldInstances
+
+-- | Does this type mention a type or data family anywhere within it? Such
+-- types are not permitted in instance heads, so the generated
+-- 'SymbolToField' instance has to bind them through an equality constraint
+-- instead (see 'allowTypeFamilies'). The walk short-circuits as soon as a
+-- family is found, and expands type synonyms so that a synonym hiding a
+-- family (e.g. @type Foo m = Family m Int@) is still detected.
+typeMentionsFamily :: Type -> Q Bool
+typeMentionsFamily = go
+  where
+    go ty =
+        case ty of
+            ConT n -> isFamily n
+            InfixT a n b -> anyM [isFamily n, go a, go b]
+            UInfixT a n b -> anyM [isFamily n, go a, go b]
+            AppT a b -> anyM [go a, go b]
+            AppKindT a _ -> go a
+            SigT a _ -> go a
+            ParensT a -> go a
+            _ -> pure False
+
+    isFamily n = do
+        info <- reify n
+        case info of
+            FamilyI{} -> pure True
+            -- Type synonyms are not recursive, so this terminates.
+            TyConI (TySynD _ _ rhs) -> go rhs
+            _ -> pure False
+
+    anyM =
+        foldr
+            (\m acc -> m >>= \found -> if found then pure True else acc)
+            (pure False)
+
+-- | The error reported when a field uses a type family but
+-- 'useTypeEquality' has not been enabled.
+typeFamilyFieldError :: Name -> Name -> Type -> String
+typeFamilyFieldError tyName fieldName typ =
+    unlines
+        [ "prairie: the field `"
+            <> nameBase fieldName
+            <> "` of `"
+            <> nameBase tyName
+            <> "` has a type that mentions a type family:"
+        , ""
+        , "    " <> pprint typ
+        , ""
+        , "Generating instances for such a field requires binding the field type"
+        , "with a `~` equality constraint, which means the calling module must"
+        , "enable the TypeOperators extension. Because that is a new requirement,"
+        , "it is opt-in. Enable it like so:"
+        , ""
+        , "    {-# LANGUAGE TypeOperators #-}"
+        , ""
+        , "    mkRecordWith defaultPrairieOptions { useTypeEquality = True } ''"
+            <> nameBase tyName
+        ]
 
 overFirst :: (Char -> Char) -> String -> String
 overFirst f str =

--- a/test/Prairie/TypeFamilySpec.hs
+++ b/test/Prairie/TypeFamilySpec.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Prairie.TypeFamilySpec where
+
+import Prairie
+
+data Mode = Foo | Bar
+
+type family Family (m :: Mode) a where
+    Family 'Foo a = a
+    Family 'Bar a = ()
+
+data Test (m :: Mode) = Test
+    { test_field1 :: Family m Int
+    , test_field2 :: Family m Bool
+    }
+
+mkRecordWith defaultPrairieOptions{useTypeEquality = True} ''Test


### PR DESCRIPTION
**Draft** — picks up #27 (by @isovector) and folds it on top of the type-variable work, reworked to be **opt-in** so it isn't a breaking change.

Stacked on #30 (`tyvars-merge`); review/merge that first. The base of this PR is the `tyvars-merge` branch, so the diff here shows only the incremental change.

## The problem

A record field whose type is a type-family application can't have that type placed directly in the `SymbolToField` instance head — type families aren't allowed there. The fix is to bind it with a `~` equality constraint:

```haskell
instance (field ~ Family m Int) => SymbolToField "test_field1" (Test m) field where ...
```

But `~` makes the **calling module** require `TypeOperators` (a `-Wtype-equality-requires-operators` warning today on GHC ≥ 9.4, a hard error later). Emitting that unconditionally would force `TypeOperators` on *every* `mkRecord` user — a breaking change for people who never touch type families.

## The design: opt-in, non-breaking

```haskell
mkRecordWith    :: PrairieOptions -> Name -> DecsQ
mkRecord         = mkRecordWith defaultPrairieOptions
defaultPrairieOptions :: PrairieOptions       -- useTypeEquality = False
useTypeEquality  :: PrairieOptions -> Bool    -- field accessor
```

- `mkRecord`'s generated code is **byte-for-byte unchanged**; no new extension for anyone who doesn't opt in.
- Opt in per-call:

```haskell
{-# LANGUAGE TypeOperators #-}

mkRecordWith defaultPrairieOptions { useTypeEquality = True } ''Test
```

- **`useTypeEquality` is named for the mechanism, not the feature.** The equality form admits any field type an instance head rejects, not just type families — that's just the most visible thing it unlocks.
- **`PrairieOptions` is abstract** (constructor not exported) — configure by record-updating `defaultPrairieOptions`. This means adding future options is not a breaking change. Verified: `PrairieOptions { ... }` fails to compile (constructor not in scope) while `defaultPrairieOptions { useTypeEquality = True }` works.
- **Named `PrairieOptions`/`defaultPrairieOptions`** rather than `Options`/`defaultOptions` to avoid clashing with aeson, which is commonly imported alongside.
- **Clever error when you forget:** using a type-family field with `useTypeEquality` off fails the splice with an actionable message rather than a confusing GHC instance-head error:

```
prairie: the field `test_field1` of `Test` has a type that mentions a type family:

    Prairie.TypeFamilySpec.Family m_0 GHC.Types.Int

Generating instances for such a field requires binding the field type
with a `~` equality constraint, which means the calling module must
enable the TypeOperators extension. Because that is a new requirement,
it is opt-in. Enable it like so:

    {-# LANGUAGE TypeOperators #-}

    mkRecordWith defaultPrairieOptions { useTypeEquality = True } ''Test
```

`typeMentionsFamily` powers the detection: it walks a field's `Type` (short-circuiting, and expanding type synonyms) so a family nested under a constructor like `Maybe (Family m Int)` — also illegal in an instance head — is caught too.

## Verification

Built and tested on **GHC 8.8.4** and **GHC 9.12.4** — 23 examples, 0 failures on both; `fourmolu --mode check` clean. Manually confirmed: (1) the opt-in error fires and points to the right fix; (2) the `PrairieOptions` constructor is hidden while record-update configuration works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)